### PR TITLE
Add ability to parse JSX files

### DIFF
--- a/lib/webpack.loaders.js
+++ b/lib/webpack.loaders.js
@@ -3,7 +3,7 @@ const webpackSharedLoaders = function (COMPONENT_NAME, COMPONENT_FOLDER, NODE_MO
     const loaders = {
         client: [
             {
-                test: /\.js$/,
+                test: /\.(js|jsx)$/,
                 include: [],
                 loader: 'eslint-loader',
                 enforce: 'pre',
@@ -13,7 +13,7 @@ const webpackSharedLoaders = function (COMPONENT_NAME, COMPONENT_FOLDER, NODE_MO
                 }
             },
             {
-                test: /\.js$/,
+                test: /\.(js|jsx)$/,
                 exclude: /node_modules/,
                 loader: 'babel-loader',
                 query: {


### PR DESCRIPTION
I think this change is needed so webpack knows what to parse the `jsx` files as.
Just adds jsx to where we define the loaders.